### PR TITLE
minor formatting fixes

### DIFF
--- a/Dwarf Therapist.tex
+++ b/Dwarf Therapist.tex
@@ -18,7 +18,7 @@
 \definecolor{addendum-content}{RGB}{233,222,219}
 
 % Syntax for intra-document section links.
-\newcommand{\jump}[1] {\textbf{``\nameref{sec:#1}}''}
+\newcommand{\jump}[1] {\textbf{``\nameref{sec:#1}''}}
 
 % Syntax for legacy boxes.
 
@@ -109,7 +109,7 @@ mappings, mods, graphical visualizers, companion programs, launchers, debuggers,
 plug-ins, extensions, program packages, so on, so forth, you get the idea, to extend and empower this
 (projected) 20 year project of a game.
 
-One such gamer is Trey Stout (or chmod, as he's known on the forums) and one such program is Dwarf
+One such gamer is Trey Stout (or \textsc{chmod}, as he's known on the forums) and one such program is Dwarf
 Therapist. Initially released in 2009, the program solves one of the most basic and annoying
 problems with the game---the difficulty involved in setting Dwarven labor preferences. In the vanilla
 game, the only way to set dwarven labor preferences (probably the most important setting there is, dwarf-
@@ -802,8 +802,8 @@ change you're making---if, for instance, you accidentally toggle Plant Gathering
 when what you really want him to be doing is chopping trees---just click on it again to revert it to the
 previous state.
 
-We've made some labor preference changes, but right now they're only hanging around in the "Pending
-Labors" queue in Dwarf Therapist. To make them actually appear in the game, we have to \textbf{commit}
+We've made some labor preference changes, but right now they're only hanging around in the ``Pending
+Labors'' queue in Dwarf Therapist. To make them actually appear in the game, we have to \textbf{commit}
 these changes. Here's what the changes we want to make look like in the Pending Labor Changes dock,
 expanded for clarity and collapsed for compactness (which is what the buttons do, if you didn't know
 already):
@@ -891,7 +891,7 @@ party is taking place, and then redesignating it. The more you know...}
 \end{wrapfigure}
 In a large enough fortress, trying to find out which dwarves are twiddling their thumbs is a
 fantastically annoying chore. Luckily, we can simplify the task for ourselves by grouping our dwarves by
-their current job. Going to the ``Group By`` drop-down menu and selecting ''Current Job'' will nicely clump
+their current job. Going to the ``Group By'' drop-down menu and selecting ``Current Job'' will nicely clump
 our dwarves by---what else---their current jobs. After a little bit of snooping, I'm able to figure out
 what the problems are. We've got three jobless Miners with nothing to mine, a Woodcrafter (but really
 Thresher) with nothing to process, a Metalcrafter with nothing to craft, and a Ranger with nothing to
@@ -1092,13 +1092,13 @@ on, you'll be able to (more) easily pick them up again and keep right on playing
 name your dwarves.
 
 Dwarven nicknames are often used rather jestingly by players, since you can name \emph{any} dwarf pretty
-much \emph{anything}, even calling your King ``Giant Poo Poo Head" and your Great Potash Maker
-``Unfortunate Accident". Dwarves don't know the difference and thus don't mind, but it's worth a cheap
-laugh from the player if ``Giant Poo Poo Head" goes to clean up the blood stain left by the demise of
-``Unfortunate Accident". However, they can actually be a pretty powerful tool if used right. By
+much \emph{anything}, even calling your King ``Giant Poo Poo Head''and your Great Potash Maker
+``Unfortunate Accident''. Dwarves don't know the difference and thus don't mind, but it's worth a cheap
+laugh from the player if ``Giant Poo Poo Head''goes to clean up the blood stain left by the demise of
+``Unfortunate Accident''. However, they can actually be a pretty powerful tool if used right. By
 nicknaming your dwarves by what their profession within your fortress is or will be, you'll be able to
 more easily keep track of who they are when you bump into them in the labor manager or on-screen. Their
-professional name might be ``Woodworker``, but to you they're ''Furnace Operator'', and using nicknames
+professional name might be ``Woodworker'', but to you they're ``Furnace Operator'', and using nicknames
 allows you to keep track of that while their professional name catches up to their new role.
 
 Let's look at one such fella for which a naming would be useful, a certain Medtob Swinwind.
@@ -1195,7 +1195,7 @@ reference. }
 \noindent \textbf{Remove Spacers}
 
 To remove the spacers from the long-form Labor view, peruse the \textbf{\nameref{sec:Screens Tab}}. Drop
-in the ``Labor NO SPACERS`` view from the menu and then delete the old one. Of course having ''NO SPACERS''
+in the ``Labor NO SPACERS'' view from the menu and then delete the old one. Of course having ``NO SPACERS''
 stare at us is quite annoying; we'll look at ways to fix this later in this guide.\footnote{Note that as
 of version 20.6 Dwarf Therapist now ships with the very view solution first presented in this guide as
 an alternative option to the default: check the ``Labors Alt'' option.}
@@ -1326,7 +1326,7 @@ nicknames, and other such simple and obvious applications.
 \label{sec:Roles}
 \subsection{What's in a Role?}
 \label{What's in a Role?}
-So far we've mentioned ``roles`` and the ''role'' they play in  Dwarf Therapist only in passing. Since we're
+So far we've mentioned ``roles'' and the ``role'' they play in  Dwarf Therapist only in passing. Since we're
 now going to discuss them in more detail, the first question we have to ask is, what's in a role?
 Have you ever had two miners work side-by-side from the very beginning of the game, but
 discovered that one reaches legendary status before the other? This happens when one dwarf is
@@ -1440,8 +1440,8 @@ two, three, and four. Of course by that point that dwarf would have put on so mu
 skill that it doesn't matter anymore---but it's still an interesting statistic to know. It's also much
 less statistically sharp than skill rank is, because base stats don't vary nearly as much as skill does.
 
-The last and most useful function that roles serve is one that answers the question "Which of these
-dwarves will reach legendary status the quickest?" In such a distribution an unskilled dwarf with minimum
+The last and most useful function that roles serve is one that answers the question ``Which of these
+dwarves will reach legendary status the quickest?'' In such a distribution an unskilled dwarf with minimum
 stats will be rated at zero percent, an accomplished one with middling stats would be a fifty, and that
 legendary +5 dwarf with maximum stats and perfect preferences and whatnot would be a one hundred: a
 \textbf{true role rating}. So, how do you turn this wonderful ranking on?
@@ -1626,8 +1626,8 @@ solution, of course, is to write our own.
 Start by copying role settings from a similarly physically demanding job---say, mining. Scroll down to
 mining in the ``Copy From'' menu (or hit M while the menu is active to get there more quickly) and click
 ``Copy''. This will copy all of the role settings for minters into the dialogue. Our haulers need not be
-lovers of picks, so let's remove it from the Preferences screen---right click on it and hit "Remove
-Selected". Skills are irrelevant, too (especially for an unskilled hauler), so remove that as well.
+lovers of picks, so let's remove it from the Preferences screen---right click on it and hit ``Remove
+Selected''. Skills are irrelevant, too (especially for an unskilled hauler), so remove that as well.
 Actually, for a hauler that's going to be carrying pretty much everything in the fortress back and forth,
 preferences are unimportant---they'll bump into pretty much everything---so let's drop stone, too.
 
@@ -1642,7 +1642,7 @@ This is what the important settings in the interface should look like at the end
 \fullfigure{Sec3Fig9}
 
 Hit ``Save'' to save your new custom role. Now, whenever you go to the Custom Roles dialogue box, hovering
-over ``Edit Custom Role`` or ''Delete Custom Role'' will give you the option to perform that action on your
+over ``Edit Custom Role'' or ``Delete Custom Role'' will give you the option to perform that action on your
 new role. Custom roles can be used in custom views and in labor optimization---we'll see an application
 for them later---but cannot yet be bound to custom professions or to labors.
 
@@ -1678,11 +1678,11 @@ basis. We're also going to assign the ``Hauler'' role that we built in the previ
 \end{wrapfigure}
 The dialogue for creating custom professions is located in one of two places, and you can get there
 either by hitting ``Create Custom Profession'' at the bottom of the Custom Professions dock, or by right
-clicking on a dwarf, going to ``Custom Professions``, and hitting ''New custom profession from this dwarf''.
+clicking on a dwarf, going to ``Custom Professions'', and hitting ``New custom profession from this dwarf''.
 This second method starts you off with the labors that that dwarf had enabled checked, and so is faster
 if you have a dwarf already set to the labors you want---and after a quick profession sort I discover
 that I do, in fact, have a peasant hanging around my fortress, so I open it up off of him. Lo and behold,
-the ten hauling ``subskills`` are already selected. I name the profession ''Hauler'' and give it a red circle
+the ten hauling ``subskills'' are already selected. I name the profession ``Hauler'' and give it a red circle
 icon, one of the spare ones in the utility's default set that's not already used by a professions. To
 make it clearer that this icon is for haulers, I'm going to use the text and text coloration option
 provided in the window to draw a white H over my icon. You can also add a background color, but the
@@ -1692,8 +1692,8 @@ display, you have to commit your changes and reload your dwarves.
 
 To work the way we intended, make sure you don't check the Mask option in the window---this will change
 the behavior so that the custom profession only masks the dwarf's ordinary profession, and it will not
-allow you to make designation changes. You can remove a dwarf's custom profession designation with "Reset
-to default profession" and then a commit to the game.
+allow you to make designation changes. You can remove a dwarf's custom profession designation with ``Reset
+to default profession'' and then a commit to the game.
 
 \begin{wrapfigure}{R}{0.40\textwidth}
 \vspace{-10pt}
@@ -1702,8 +1702,8 @@ to default profession" and then a commit to the game.
   \end{center}
 \vspace{-10pt}
 \end{wrapfigure}
-You can create a mask more directly by right clicking on the dwarf and then going to "Set custom
-profession name" under the custom professions menu, and then inputting a name: once committed this will
+You can create a mask more directly by right clicking on the dwarf and then going to ``Set custom
+profession name'' under the custom professions menu, and then inputting a name: once committed this will
 change the dwarf's profession to a custom one. This is a by-dwarf operation that basically mirrors how
 custom professions work within the game, replacing the dwarf's professional name with the new string but
 not changing anything else, without labor assignments or a custom icon, and with no facilities for
@@ -1781,8 +1781,8 @@ views can only be created and edited through the associated dock, so if you don'
 so at least for the duration of your editing.
 
 Inside the dock you will find the grid views that the utility comes pre-loaded with, but they will be
-grayed out. You can create a new, editable grid view in one of two ways: either by hitting "Add New Grid
-View", which gives you a blank, or by right clicking on and copying one of the views that is already
+grayed out. You can create a new, editable grid view in one of two ways: either by hitting ``Add New Grid
+View'', which gives you a blank, or by right clicking on and copying one of the views that is already
 hardcoded in, which will generate you an editable copy of the view.\footnote{Note that the grid views
 that come hard-coded with the utility cannot be deleted.} At right you can see what the grid views dock
 looks like with one custom view, ``Recruitment'', already defined.
@@ -1936,7 +1936,7 @@ Right clicking on a set allows you to either modify it or delete it entirely. Ed
 to change its name (again, merely organizational) and its coloration---there are a number of predefined
 options, but by going to the\texttt{ [...]} option you can choose and use any hex value.\footnote{For
 some reason choosing a new color sometimes doesn't change the color of the header. Going through the
-menus and just pressing ``OK" again fixes this bug.} Clicking on an empty space in the box creates a new,
+menus and just pressing ``OK'' again fixes this bug.} Clicking on an empty space in the box creates a new,
 empty set for editing. To rearrange the position of a set, simply grab and tug it up or down.
 
 The columns themselves are color-codes to match their sets, but if you edit them you'll be able to
@@ -2147,7 +2147,7 @@ the side or expand it to take up the whole view by dragging the right edge of th
 
 Filter scripts work by generating a boolean test for your dwarves and then iterating through them. Dwarf
 Therapist handles looping for you, so your job is simply to write a useful filter: basically, at the end
-of the application of your filter to a dwarf, we want to end up with either a ``true`` or ''false''
+of the application of your filter to a dwarf, we want to end up with either a ``true'' or ``false''
 statement. If the result is false, the dwarf will not be displayed; if it is true, they will be. All of
 the commands that you can enter into the script editor are all meant to be called on the ``d'' object, the
 abstracted dwarf in question, through the dot operator: \texttt{d.is\_child()}, for instance. The
@@ -2177,7 +2177,7 @@ some of the commands available to you:
 \texttt{total\_assigned\_labors()} & integer & Returns the total number of assigned labors for this dwarf.\\
 \multicolumn{3}{r}{Optionally takes a boolean value: if set to false, does not include hauling labors.}\\
 \multicolumn{3}{l}{\texttt{skill\_level(int skill\_id, bool raw, bool precise)}}\\
-\multicolumn{3}{r}{Returns a floating point value, or ``float".}\\
+\multicolumn{3}{r}{Returns a floating point value, or ``float''.}\\
 \multicolumn{3}{r}{Raw uses the uncapped skill level, precise returns a decimal skill level.}\\
 \multicolumn{3}{l}{\texttt{has\_health\_issue(category, index)}\quad boolean}\\
 \multicolumn{3}{r}{Returns the health status of this dwarf.}\\
@@ -2238,8 +2238,8 @@ operating furnaces, some will build parts for your pump stack, some will be enli
 
 In  \jump{Using Roles} we discussed combining groups, sorts, and roles to find ideal
 dwarves for a particular task within a group, but we were hamstrung by the limitations of a group:
-there's no easy way to group ``gainfully employed" dwarves committed to their tasks apart from
-``part-time" ones that aren't. Your options were to make do with grouping them into migrant waves, which
+there's no easy way to group ``gainfully employed'' dwarves committed to their tasks apart from
+``part-time'' ones that aren't. Your options were to make do with grouping them into migrant waves, which
 doesn't usually end with you selecting the best available dwarf in the \emph{fortress} for the task, or
 not grouping them at all, which requires you browse through dwarves that are already working on something
 and risks switching the tasks of a dwarf you'd designated for a new role earlier (a problem discussed in
@@ -2249,23 +2249,23 @@ script we're going to write.
 \fullfigure{Sec4Fig2}
 \fullfigurecaption{In my fort I just started funneling my dwarves into tower fortress building duty.}
 
-Whenever you write a script the first question you've got to ask is, "what are the characteristics of a
-dwarf that I want`` (if you're writing an \emph{inclusive} script), or ''what are the characteristics of a
-dwarf that I \emph{don't} want" (if you're writing an \emph{exclusive} one). In this case we're writing
+Whenever you write a script the first question you've got to ask is, ``what are the characteristics of a
+dwarf that I want'' (if you're writing an \emph{inclusive} script), or ``what are the characteristics of a
+dwarf that I \emph{don't} want'' (if you're writing an \emph{exclusive} one). In this case we're writing
 an inclusive filter meant to root out migrant dwarves that are available for full-time assignment to
 useful tasks. If we think about what this implies, we can come up with a number of ``characteristics'' for
 such dwarves (in order of complexity):
 
 \begin{enumerate}
 \item They have all hauling labors enabled. This is one of the most apparent indicators of a
-``working-class" dwarf, but it's nowhere near exclusive.
+``working-class'' dwarf, but it's nowhere near exclusive.
 
 \item They don't have a nickname. Assuming you follow the advice given in
 \jump{Assigning Nicknames}, nicked dwarves have already been dedicated to something.
 
 \item They have the masonry and/or stone detailing labors enabled, but are never above ``adequate'' skill
 in the former (since actually building stone blocks is assigned to dedicated masons), and never above
-``competent`` in the latter (I consider ``skilled'' the breaking point for when an engraver is actually worth
+``competent'' in the latter (I consider ``skilled'' the breaking point for when an engraver is actually worth
 his salt, and should be taken out of the working-class pool).
 
 \item They are never enlisted in the military (at least, not permanently). At least in \emph{my}
@@ -2329,7 +2329,7 @@ d.labor_enabled(13) == false)||
 d.labor_enabled(12) == false))
 \end{verbatim}
 
-Then we create a new ``Available for Work" script, and within it link the two statements we've written so
+Then we create a new ``Available for Work'' script, and within it link the two statements we've written so
 far with an AND. So far, so good: on to the next condition.
 \vspace{12pt}
 
@@ -2498,7 +2498,7 @@ optimizer that we want all of the jobs that these dwarves can be assigned to be 
 optimization scheme.
 
 Roll your mouse over the empty white space and right click to bring up a menu of labors, and select first
-``Wood Burning`` and second ``Smelting'' from the list. You can add any number of labors to the list in
+``Wood Burning'' and second ``Smelting'' from the list. You can add any number of labors to the list in
 this manner, and you can easily delete any labors you've already added by right clicking and hitting
 ``Remove Selected''.
 
@@ -2537,9 +2537,9 @@ operators but only two wood burners.
 \fullfigure{Sec4Fig10}
 
 Now let's add a fold of complexity to our plan by including hauling as well. To edit an optimization
-plan, go to ``Optimizer`` on the taskbar and select the plan from the ``Edit Optimization Plan'' menu. This
+plan, go to ``Optimizer'' on the taskbar and select the plan from the ``Edit Optimization Plan'' menu. This
 time let's turn auto-assign haulers on and set it to 50 percent: likewise, set the total jobs percentage
-to 50 as well. Now hit ``Test Optimize" at the bottom of the window to see what effect this plan has on
+to 50 as well. Now hit ``Test Optimize'' at the bottom of the window to see what effect this plan has on
 our dwarves (I deliberately avoided doing this earlier to showcase predefined usage and the changes to
 the menu bar). As you might have guessed this cleaves our dwarves in two: a quarter each are assigned
 dedicated wood burning or furnace operating, and the remaining half are made haulers, with their other
@@ -2610,7 +2610,7 @@ is not the case: rather, that percentage is a bit of dwarf-wise post-processing 
 many labors that dwarf already has assigned.
 
 Basically, the optimizer assigns labors, then goes down the list and asks each dwarf how many labors they
-have assigned: one? Two? None? It then compares this to the ``Hauler Percent" value (hauler threshold
+have assigned: one? Two? None? It then compares this to the ``Hauler Percent'' value (hauler threshold
 from now on), and if the dwarf has fewer than that percent of the maximum number of labors assigned, then
 they are assigned hauling tasks. In the example above every dwarf has both labors enabled, and so
 obviously no dwarf falls under the fifty percent threshold---and no dwarf is assigned hauling. In example
@@ -2648,7 +2648,7 @@ disbanded.
 
 As it turns out, dwarf number five in our examples above is actually a noble---I just haven't been
 excluding him in the optimization process. Doing so results in exactly the sort of behavior you would
-expect---he's ignored---and has the nice side effect of tidying up our ``five divided by two" problem.
+expect---he's ignored---and has the nice side effect of tidying up our ``five divided by two'' problem.
 \fullfigure{Sec4Fig15}
 
 \subsection{Using Optimization Plans}
@@ -2700,10 +2700,10 @@ available: as labor management has been given a GUI by the community, so to has 
 modification. I'm also not going to pretend I fully understand how the tool even \emph{works}.
 
 Additionally, if you right click on a dwarf's name and scroll to ``Memory Tools'' you will see that there
-are some memory options available for individual dwarves as well. You can ``Dump Memory" to open the
-memory matrix associated with that dwarf tabulated in a text box by the program. ``Dump Memory to File"
+are some memory options available for individual dwarves as well. You can ``Dump Memory''to open the
+memory matrix associated with that dwarf tabulated in a text box by the program. ``Dump Memory to File''
 will also read the dwarf's memory values into a chart, but will save it to a \texttt{TXT} file in the
-Dwarf Therapist log subfolder. Finally, you can ``Copy Address to Clipboard" to copy that dwarf's memory
+Dwarf Therapist log subfolder. Finally, you can ``Copy Address to Clipboard'' to copy that dwarf's memory
 location to your clipboard. This function may be useful if you're interested in modding your dwarves
 in-game, but once again it's not something the average user would need.
 \end{flushleft}

--- a/Dwarf Therapist.tex
+++ b/Dwarf Therapist.tex
@@ -2700,7 +2700,7 @@ available: as labor management has been given a GUI by the community, so to has 
 modification. I'm also not going to pretend I fully understand how the tool even \emph{works}.
 
 Additionally, if you right click on a dwarf's name and scroll to ``Memory Tools'' you will see that there
-are some memory options available for individual dwarves as well. You can ``Dump Memory''to open the
+are some memory options available for individual dwarves as well. You can ``Dump Memory'' to open the
 memory matrix associated with that dwarf tabulated in a text box by the program. ``Dump Memory to File''
 will also read the dwarf's memory values into a chart, but will save it to a \texttt{TXT} file in the
 Dwarf Therapist log subfolder. Finally, you can ``Copy Address to Clipboard'' to copy that dwarf's memory


### PR DESCRIPTION
- use standard TeX quotes (` ``...'' `) throughout
 - to eliminate typographical problems like ”Read Dwarves”
